### PR TITLE
Added blade directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ INVISIBLE_RECAPTCHA_DEBUG=false
 
 ### Usage
 
-##### Display reCAPTCHA
+##### Display reCAPTCHA in a Blade template
 
 ```php
-{!! app('captcha')->render(); !!}
+@captcha()
 ```
 
 With custom language support:
 
 ```
-{!! app('captcha')->render($lang = null); !!}
+@captcha($lang = null)
 ```
 
 ##### Validation

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^6.1",
+        "illuminate/view": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/InvisibleReCaptchaServiceProvider.php
+++ b/src/InvisibleReCaptchaServiceProvider.php
@@ -3,21 +3,25 @@
 namespace AlbertCht\InvisibleReCaptcha;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Compilers\BladeCompiler;
 
 class InvisibleReCaptchaServiceProvider extends ServiceProvider
 {
     /**
      * Boot the services for the application.
      *
+     * @param BladeCompiler $blade
      * @return void
      */
-    public function boot()
+    public function boot(BladeCompiler $blade)
     {
         $app = $this->app;
         $this->bootConfig();
         $this->app['validator']->extend('captcha', function ($attribute, $value) use ($app) {
             return $app['captcha']->verifyResponse($value, $app['request']->getClientIp());
         });
+
+        $this->addBladeDirective($blade);
     }
 
     /**
@@ -61,5 +65,16 @@ class InvisibleReCaptchaServiceProvider extends ServiceProvider
     public function provides()
     {
         return ['captcha'];
+    }
+
+    /**
+     * @param BladeCompiler $blade
+     * @return void
+     */
+    public function addBladeDirective(BladeCompiler $blade)
+    {
+        $blade->directive('captcha', function ($lang) {
+            return "<?php echo app('captcha')->render(" . ($lang ? "'$lang'" : '') . '); ?>';
+        });
     }
 }


### PR DESCRIPTION
This makes usage in Laravel way more natural.

```php
@captcha()

or 

@captcha($lang)
```

Test is pretty fragile, but at least it checks that blade is detecting and compiling properly to the `app()` call.
I've also changed your `__construct` call in your test to a `setUp` method.