### PR TITLE
Feature/propagate form submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ if (!empty($_POST)) {
 Use this function only when you need to take all control after clicking submit button. Recaptcha validation will not be triggered if you return false in this function.
 
 ```javascript
-_beforeSubmit = function() {
+_beforeSubmit = function(e) {
     console.log('submit button clicked.');
     // do other things before captcha validation
+    // e represents reference to original form submit event
     // return true if you want to continue triggering captcha validation, otherwise return false
     return false;
 }

--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -106,7 +106,7 @@ class InvisibleReCaptcha
         $html .= 'grecaptcha.reset();}else{_captchaForm.submit();}};';
         $html .= "_captchaForm.addEventListener('submit',";
         $html .= "function(e){e.preventDefault();if(typeof _beforeSubmit==='function'){";
-        $html .= "_execute=_beforeSubmit();}if(_execute){grecaptcha.execute();}});";
+        $html .= "_execute=_beforeSubmit(e);}if(_execute){grecaptcha.execute();}});";
         if ($this->getOption('debug', false)) {
             $html .= $this->renderDebug();
         }


### PR DESCRIPTION
I find having form reference quite useful to run my own validation before executing grecaptcha, and the easiest approach is to pass form submit event to _beforeSubmit. There one can use e.currentTarget to obtain form reference, but there could be other applications for this event there as well. Therefore let me pass this along if you consider this small change useful upstream.

Many thanks for this lib, much appreciated!