### PR TITLE
Fix reset is called before submitted

### DIFF
--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -97,7 +97,7 @@ class InvisibleReCaptcha
         $html .= '_renderedTimes=$("._g-recaptcha").length;_captchaForms=$("._g-recaptcha").closest("form");';
         $html .= '_captchaForms.each(function(){$(this)[0].addEventListener("submit",function(e){e.preventDefault();';
         $html .= '_captchaForm=$(this);_submitBtn=$(this).find(":submit");grecaptcha.execute();});});';
-        $html .= '_submitForm=function(){_submitBtn.trigger("captcha");grecaptcha.reset();if(_submitAction){_captchaForm.submit();}};';
+        $html .= '_submitForm=function(){_submitBtn.trigger("captcha");if(_submitAction){_captchaForm.submit();}grecaptcha.reset();};';
         $html .= '_captchaCallback=function(){grecaptcha.render("_g-recaptcha_"+_renderedTimes,';
         $html .= "{sitekey:'{$this->siteKey}',size:'invisible',callback:_submitForm});}";
         $html .= '});</script>' . PHP_EOL;


### PR DESCRIPTION
Currently in the `_submitForm` function `grecaptcha.reset()` is called before the `_submitAction` check and subsequent `_captchaForm.submit()` call, hence when the form is submitted as a normal form (not using the captcha trigger) the `g-recaptcha-response` is empty/null.

May be related to #81 and may be a similar issue causing #86 (The script seems a bit different and I was only interested in the multi-forms implementation)

I haven't looked yet but I think _captchaCallback should loop through the ._g-recaptcha elements and call render on each. Also grecaptcha.execute and grecaptcha.reset should pass the opt_widget_id paramter but I haven't figured out how to adapt it yet.