### PR TITLE
Handle Guzzle Exceptions

### DIFF
--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -191,11 +191,16 @@ class InvisibleReCaptcha
             return false;
         }
 
-        $response = $this->sendVerifyRequest([
-            'secret' => $this->secretKey,
-            'remoteip' => $clientIp,
-            'response' => $response
-        ]);
+        try {
+            $response = $this->sendVerifyRequest([
+                'secret'   => $this->secretKey,
+                'remoteip' => $clientIp,
+                'response' => $response
+            ]);
+        } catch (\GuzzleHttp\Exception\GuzzleException $exception) {
+            \Illuminate\Support\Facades\Log::error($exception->getMessage());
+            return true;
+        }
 
         return isset($response['success']) && $response['success'] === true;
     }


### PR DESCRIPTION
Today, I had a nice error : "Could not resolve host: www.google.com".
Even if it's probably a problem with my server, it blocked the registration to my service... I think it would be a good idea to send "true" during a Guzzle Exception to avoid this.