### PR TITLE
Javascript Fails when using custom minify methods.

### DIFF
--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -135,7 +135,7 @@ class InvisibleReCaptcha
         $html .= "<script>window.addEventListener('load', _loadCaptcha);" . PHP_EOL;
         $html .= "function _loadCaptcha(){";
         if ($this->getOption('hideBadge', false)) {
-            $html .= "document.querySelector('.grecaptcha-badge').style = 'display:none;!important'" . PHP_EOL;
+            $html .= "document.querySelector('.grecaptcha-badge').style = 'display:none !important;';" . PHP_EOL;
         }
         $html .= '_captchaForm=document.querySelector("#_g-recaptcha").closest("form");';
         $html .= "_captchaSubmit=_captchaForm.querySelector('[type=submit]');";


### PR DESCRIPTION
This spesific line breaks javascript and causes 

Uncaught SyntaxError: Unexpected identifier

when using minified html response.