### PR TITLE
Adding script nonce parameter for Content Security Policy headers

### DIFF
--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -88,11 +88,11 @@ class InvisibleReCaptcha
      *
      * @return string
      */
-    public function render($lang = null)
+    public function render($lang = null, $nonce = null)
     {
         $html = $this->renderPolyfill();
         $html .= $this->renderCaptchaHTML();
-        $html .= $this->renderFooterJS($lang);
+        $html .= $this->renderFooterJS($lang, $nonce);
         return $html;
     }
 
@@ -128,9 +128,13 @@ class InvisibleReCaptcha
      *
      * @return string
      */
-    public function renderFooterJS($lang = null)
+    public function renderFooterJS($lang = null, $nonce = null)
     {
-        $html = '<script src="' . $this->getCaptchaJs($lang) . '" async defer></script>' . PHP_EOL;
+        $html = '<script src="' . $this->getCaptchaJs($lang) . '" async defer';
+        if (isset($nonce) && !empty($nonce)){
+            $html .= ' nonce="' . $nonce . '"';
+        }
+        $html .= '></script>' . PHP_EOL;
         $html .= '<script>var _submitForm,_captchaForm,_captchaSubmit,_execute=true;</script>';
         $html .= "<script>window.addEventListener('load', _loadCaptcha);" . PHP_EOL;
         $html .= "function _loadCaptcha(){";

--- a/src/InvisibleReCaptchaServiceProvider.php
+++ b/src/InvisibleReCaptchaServiceProvider.php
@@ -81,8 +81,8 @@ class InvisibleReCaptchaServiceProvider extends ServiceProvider
         $blade->directive('captchaHTML', function () {
             return "<?php echo app('captcha')->renderCaptchaHTML(); ?>";
         });
-        $blade->directive('captchaScripts', function ($lang) {
-            return "<?php echo app('captcha')->renderFooterJS({$lang}); ?>";
+        $blade->directive('captchaScripts', function ($lang, $nonce) {
+            return "<?php echo app('captcha')->renderFooterJS({$lang, $nonce}); ?>";
         });
     }
 }

--- a/src/InvisibleReCaptchaServiceProvider.php
+++ b/src/InvisibleReCaptchaServiceProvider.php
@@ -82,7 +82,7 @@ class InvisibleReCaptchaServiceProvider extends ServiceProvider
             return "<?php echo app('captcha')->renderCaptchaHTML(); ?>";
         });
         $blade->directive('captchaScripts', function ($lang, $nonce) {
-            return "<?php echo app('captcha')->renderFooterJS({$lang, $nonce}); ?>";
+            return "<?php echo app('captcha')->renderFooterJS({$lang}, {$nonce}); ?>";
         });
     }
 }


### PR DESCRIPTION
Adding optional nonce parameter so rendered html will contain script tag with nonce parameter. Adding same nonce to `script-src` of SCP headers will allow this script to be executed.