### PR TITLE
Add semicolon in render footer JS.

### DIFF
--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -135,7 +135,7 @@ class InvisibleReCaptcha
         $html .= "<script>window.addEventListener('load', _loadCaptcha);" . PHP_EOL;
         $html .= "function _loadCaptcha(){";
         if ($this->getOption('hideBadge', false)) {
-            $html .= "document.querySelector('.grecaptcha-badge').style = 'display:none;!important'" . PHP_EOL;
+            $html .= "document.querySelector('.grecaptcha-badge').style = 'display:none;!important';" . PHP_EOL;
         }
         $html .= '_captchaForm=document.querySelector("#_g-recaptcha").closest("form");';
         $html .= "_captchaSubmit=_captchaForm.querySelector('[type=submit]');";


### PR DESCRIPTION
When the website has compressed HTML, an error will occur if there is no semicolon in this place.

![image](https://user-images.githubusercontent.com/9282137/92067228-58fd4900-edd6-11ea-8916-0008153e3798.png)
