### PR TITLE
Fix blade directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - '7.2'
   - '7.3'
+  - '7.4'
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist --no-suggest

--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -102,9 +102,9 @@ class InvisibleReCaptcha
      *
      * @return string
      */
-    public function renderCaptcha($arguments)
+    public function renderCaptcha(...$arguments)
     {
-        return $this->render($arguments);
+        return $this->render(...$arguments);
     }
 
     /**
@@ -139,7 +139,7 @@ class InvisibleReCaptcha
      *
      * @return string
      */
-    public function renderFooterJS($arguments)
+    public function renderFooterJS(...$arguments)
     {
         $lang = Arr::get($arguments, 0);
         $nonce = Arr::get($arguments, 1);

--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -2,6 +2,7 @@
 
 namespace AlbertCht\InvisibleReCaptcha;
 
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Request;
 use GuzzleHttp\Client;
 
@@ -92,7 +93,7 @@ class InvisibleReCaptcha
     {
         $html = $this->renderPolyfill();
         $html .= $this->renderCaptchaHTML();
-        $html .= $this->renderFooterJS($lang, $nonce);
+        $html .= $this->renderFooterJS([$lang, $nonce]);
         return $html;
     }
 
@@ -128,8 +129,11 @@ class InvisibleReCaptcha
      *
      * @return string
      */
-    public function renderFooterJS($lang = null, $nonce = null)
+    public function renderFooterJS($arguments)
     {
+        $lang = Arr::get($arguments, 0);
+        $nonce = Arr::get($arguments, 1);
+
         $html = '<script src="' . $this->getCaptchaJs($lang) . '" async defer';
         if (isset($nonce) && ! empty($nonce)) {
             $html .= ' nonce="' . $nonce . '"';

--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -98,6 +98,16 @@ class InvisibleReCaptcha
     }
 
     /**
+     * Render HTML reCaptcha from directive.
+     *
+     * @return string
+     */
+    public function renderCaptcha($arguments)
+    {
+        return $this->render($arguments);
+    }
+
+    /**
      * Render the polyfill JS components only.
      *
      * @return string

--- a/src/InvisibleReCaptchaServiceProvider.php
+++ b/src/InvisibleReCaptchaServiceProvider.php
@@ -73,7 +73,7 @@ class InvisibleReCaptchaServiceProvider extends ServiceProvider
     public function addBladeDirective(BladeCompiler $blade)
     {
         $blade->directive('captcha', function ($arguments) {
-            return "<?php echo app('captcha')->render({$arguments}); ?>";
+            return "<?php echo app('captcha')->renderCaptcha({$arguments}); ?>";
         });
         $blade->directive('captchaPolyfill', function () {
             return "<?php echo app('captcha')->renderPolyfill(); ?>";

--- a/src/InvisibleReCaptchaServiceProvider.php
+++ b/src/InvisibleReCaptchaServiceProvider.php
@@ -72,8 +72,8 @@ class InvisibleReCaptchaServiceProvider extends ServiceProvider
      */
     public function addBladeDirective(BladeCompiler $blade)
     {
-        $blade->directive('captcha', function ($lang) {
-            return "<?php echo app('captcha')->render({$lang}); ?>";
+        $blade->directive('captcha', function ($arguments) {
+            return "<?php echo app('captcha')->render({$arguments}); ?>";
         });
         $blade->directive('captchaPolyfill', function () {
             return "<?php echo app('captcha')->renderPolyfill(); ?>";
@@ -81,8 +81,8 @@ class InvisibleReCaptchaServiceProvider extends ServiceProvider
         $blade->directive('captchaHTML', function () {
             return "<?php echo app('captcha')->renderCaptchaHTML(); ?>";
         });
-        $blade->directive('captchaScripts', function ($lang, $nonce) {
-            return "<?php echo app('captcha')->renderFooterJS({$lang}, {$nonce}); ?>";
+        $blade->directive('captchaScripts', function ($arguments) {
+            return "<?php echo app('captcha')->renderFooterJS({$arguments}); ?>";
         });
     }
 }

--- a/tests/CaptchaTest.php
+++ b/tests/CaptchaTest.php
@@ -59,6 +59,11 @@ class CaptchaTest extends TestCase
         $this->assertEquals($js . '?hl=us', $this->captcha->getCaptchaJs('us'));
     }
 
+    public function testJavascriptHasNonce()
+    {
+        $this->assertStringContainsString('nonce="nonce-ASDFGHJKL"', $this->captcha->renderFooterJS('us', 'nonce-ASDFGHJKL'));
+    }
+
     public function testGetPolyfillJs()
     {
         $js = 'https://cdn.polyfill.io/v2/polyfill.min.js';
@@ -79,10 +84,44 @@ class CaptchaTest extends TestCase
         $serviceProvider = new InvisibleReCaptchaServiceProvider($app);
         $serviceProvider->addBladeDirective($blade);
 
-        $result = $blade->compileString('@captcha()');
         $this->assertEquals(
-            "<?php echo app('captcha')->render(); ?>",
-            $result
+            "<?php echo app('captcha')->renderCaptcha(); ?>",
+            $blade->compileString('@captcha()')
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderCaptcha('us'); ?>",
+            $blade->compileString("@captcha('us')")
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderCaptcha('us', 'nonce-ASDFGHJKL'); ?>",
+            $blade->compileString("@captcha('us', 'nonce-ASDFGHJKL')")
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderPolyfill(); ?>",
+            $blade->compileString('@captchaPolyfill()')
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderCaptchaHTML(); ?>",
+            $blade->compileString('@captchaHTML()')
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderFooterJS(); ?>",
+            $blade->compileString('@captchaScripts()')
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderFooterJS('us'); ?>",
+            $blade->compileString("@captchaScripts('us')")
+        );
+
+        $this->assertEquals(
+            "<?php echo app('captcha')->renderFooterJS('us', 'nonce-ASDFGHJKL'); ?>",
+            $blade->compileString("@captchaScripts('us', 'nonce-ASDFGHJKL')")
         );
     }
 }


### PR DESCRIPTION
#125 added the ability to add nonces to the scripts, but the implementation was not correct.

Blade passes all the arguments as a string (for example: `"'en', 'nonce-ASDFGHJKL'"`) to the closure. After Blade compiles the view, the underlying function (`app('captcha')->renderFooterJS(...)`) receives the arguments as they were passed.

This can be further simplified by using array destructuring, which means dropping support for PHP 5.6 and 7.0.